### PR TITLE
fix: reset prompt guards on abort to prevent soft-lock window

### DIFF
--- a/providers/opencode-provider.tsx
+++ b/providers/opencode-provider.tsx
@@ -1592,6 +1592,12 @@ export function OpencodeProvider({ children }: PropsWithChildren) {
       await clearPendingTaskFinishedNotification(sessionId);
       await client.session.abort({ sessionID: sessionId });
 
+      // Reset prompt guards immediately so the user can submit again without
+      // waiting for the in-flight promptAsync to settle. sendPrompt's finally
+      // block sets the same values; both writes compose to the same state.
+      promptSubmissionRef.current = { active: false, sessionId: undefined };
+      setSendingState((prev) => (prev.active ? { active: false, sessionId: undefined } : prev));
+
       await Promise.all([
         refreshSessions(true),
         refreshMessages(sessionId, true),


### PR DESCRIPTION
## Problem

\bortSession\ resets the running session on the server but does not clear the client-side guards (\promptSubmissionRef\ + \sendingState.active\). Until the in-flight \promptAsync\ promise settles, those guards stay active, blocking new prompt submission and leaving the conversation-mode state machine in a half-running state.

## Fix

Clear \promptSubmissionRef.current = false\ and \setSendingState({ active: false })\ inside \bortSession\ so the client immediately returns to an idle, submittable state. Server abort and client guards are now decoupled — either settling first no longer blocks the UI.

## Files changed

- \providers/opencode-provider.tsx\ (+6 LOC)

## Validation

- \
pm run typecheck\ ✓
- \
pm run lint\ ✓
- \
pm run test:fake-server:self\ ✓

## Notes

Optional follow-up hardening: scope the reset to the aborting \sessionId\ so aborting session A does not clear session B's lock (rare in practice — single active send at a time). 1-line change.