### PR TITLE
fix: clear session refresh timers on project switch

### DIFF
--- a/providers/opencode-provider.tsx
+++ b/providers/opencode-provider.tsx
@@ -336,6 +336,13 @@ export function OpencodeProvider({ children }: PropsWithChildren) {
     pendingNotificationSessionIdsRef.current.clear();
     busyNotificationSessionIdsRef.current.clear();
     notificationRequestedAtRef.current.clear();
+    // Cancel pending session refresh timers. Without this, timeouts scheduled
+    // for sessions in the previous project keep firing after a project switch,
+    // running refresh callbacks that capture stale client instances and write
+    // into state slices that were just cleared above.
+    Object.values(sessionRefreshTimeoutsRef.current).forEach((timeout) => clearTimeout(timeout));
+    sessionRefreshTimeoutsRef.current = {};
+    sessionRefreshOptionsRef.current = {};
     setCurrentSessionId(undefined);
     setSessions([]);
     setArchivedSessions([]);


### PR DESCRIPTION
## Problem

\clearProjectState\ (fires on project switch) clears in-memory session state but does not clear the debounced session-refresh timeouts in \sessionRefreshTimeoutsRef\ / \sessionRefreshOptionsRef\. A queued timeout can fire after the switch and write state for the old project into the new project's session maps.

## Fix

Iterate \sessionRefreshTimeoutsRef.current\, \clearTimeout\ each entry, and reset both refs before \setCurrentSessionId(undefined)\. Order matters: timers cleared before session ID changes so any in-flight callback reads stale state and no-ops.

## Files changed

- \providers/opencode-provider.tsx\ (+7 LOC)

## Validation

- \
pm run typecheck\ ✓
- \
pm run lint\ ✓
- \
pm run test:fake-server:self\ ✓

## Notes

Pattern is byte-identical to the existing unmount cleanup at opencode-provider.tsx:2245-2247 — same \Object.values(...).forEach(clearTimeout)\ + ref reset shape. Deps \[]\ unaffected.