### PR TITLE
fix: stop microphone when app is backgrounded

### DIFF
--- a/providers/opencode-provider.tsx
+++ b/providers/opencode-provider.tsx
@@ -28,7 +28,7 @@ import {
   useState,
   type PropsWithChildren,
 } from 'react';
-import { Platform } from 'react-native';
+import { AppState, Platform } from 'react-native';
 
 import {
   buildClient,
@@ -1656,6 +1656,23 @@ export function OpencodeProvider({ children }: PropsWithChildren) {
     setConversationPhase('submitting');
   }, [abortSpeechInput, clearPendingConversationResult]);
   flushPendingConversationResultRef.current = flushPendingConversationResult;
+
+  // Stop the microphone when the app is backgrounded or the provider unmounts.
+  // Without this, speech recognition stays active after the user switches apps,
+  // continuing to capture audio in the background (privacy + battery cost).
+  // abort() is safe to call when not listening — the underlying native call is
+  // wrapped in try/catch inside useSpeechInput.
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state !== 'active') {
+        abortSpeechInput();
+      }
+    });
+    return () => {
+      subscription.remove();
+      abortSpeechInput();
+    };
+  }, [abortSpeechInput]);
 
   const getLatestConversationAssistantEntry = useCallback(
     (sessionId?: string) => {


### PR DESCRIPTION
## Problem

Speech recognition stays active when the app is backgrounded. The microphone keeps listening, draining battery and raising privacy concerns. Provider unmount cleanup calls `stopSpeaking` and `unloadWorkingSoundAsync` but never `abortSpeechInput`. `ChatView` has no unmount cleanup at all.

## Fix

Add an `AppState` listener in the provider that fires `abortSpeechInput()` on `background`/`inactive` transitions. Also added to the unmount cleanup so backgrounding or tearing down the app properly releases the mic.

## Files changed

- `providers/opencode-provider.tsx` (+18 / -1 LOC)

## Validation

- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm run test:fake-server:self` ✓

## Notes

- Uses `AppState.addEventListener` (modern RN API). Cleanup via `subscription.remove()` — no deprecated `removeEventListener`.
- `abortSpeechInput` is synchronous (try/catch + setState internally), so no floating-promise concern.
- Conversation-mode half-state on background is intentional: mic stops, TTS/working-sound continue so a spoken reply can finish. Caller can extend to fully tear down conversation mode if desired.
