### PR TITLE
feat: add native iOS CI/CD with GitHub Actions

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -1,0 +1,191 @@
+name: iOS Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload_to_app_store:
+        description: Upload the build to App Store Connect / TestFlight
+        required: false
+        default: false
+        type: boolean
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  build-ios:
+    runs-on: macos-latest
+    permissions:
+      contents: read
+
+    env:
+      EXPO_APP_VARIANT: production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate iOS native project
+        run: npx expo prebuild --platform ios --non-interactive
+
+      - name: Detect workspace
+        id: workspace
+        run: |
+          WORKSPACE=$(find ios -name "*.xcworkspace" -maxdepth 1 | head -1)
+          if [ -z "$WORKSPACE" ]; then
+            echo "No .xcworkspace found"
+            exit 1
+          fi
+          echo "path=$WORKSPACE" >> "$GITHUB_OUTPUT"
+          echo "name=$(basename "$WORKSPACE" .xcworkspace)" >> "$GITHUB_OUTPUT"
+
+      - name: Detect scheme
+        id: scheme
+        run: |
+          SCHEME=$(xcodebuild -workspace "${{ steps.workspace.outputs.path }}" -list -json | python3 -c "import sys,json; print(json.load(sys.stdin)['project']['schemes'][0])")
+          echo "name=$SCHEME" >> "$GITHUB_OUTPUT"
+
+      - name: Create temporary keychain
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 24)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"
+
+      - name: Import distribution certificate
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          CERT_PATH=$RUNNER_TEMP/certificate.p12
+          printf '%s' "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+      - name: Install provisioning profile
+        env:
+          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
+          printf '%s' "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          UUID=$(security cms -D -i "$PROFILE_PATH" | plutil -extract UUID raw -)
+          cp "$PROFILE_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/"$UUID".mobileprovision
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: ios/Pods
+          key: pods-${{ runner.os }}-${{ steps.workspace.outputs.name }}-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            pods-${{ runner.os }}-${{ steps.workspace.outputs.name }}-
+
+      - name: Install CocoaPods dependencies
+        run: pod install
+        working-directory: ios
+
+      - name: Determine build number
+        id: buildnum
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            BUILD_NUMBER=$(date +%Y%m%d)001
+          else
+            BUILD_NUMBER=${{ github.run_number }}
+          fi
+          echo "value=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Build archive
+        run: |
+          xcodebuild -workspace "${{ steps.workspace.outputs.path }}" \
+            -scheme "${{ steps.scheme.outputs.name }}" \
+            -configuration Release \
+            -archivePath "$RUNNER_TEMP/build.xcarchive" \
+            -destination "generic/platform=iOS" \
+            -allowProvisioningUpdates \
+            DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
+            CURRENT_PROJECT_VERSION="${{ steps.buildnum.outputs.value }}" \
+            COMPILER_INDEX_STORE_ENABLE=NO
+
+      - name: Verify archive
+        run: |
+          if [ ! -d "$RUNNER_TEMP/build.xcarchive" ]; then
+            echo "Archive not found"
+            exit 1
+          fi
+
+      - name: Export IPA
+        run: |
+          cat > "$RUNNER_TEMP/ExportOptions.plist" << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>app-store</string>
+            <key>teamID</key>
+            <string>${{ secrets.APPLE_TEAM_ID }}</string>
+            <key>uploadBitcode</key>
+            <false/>
+            <key>compileBitcode</key>
+            <false/>
+            <key>uploadSymbols</key>
+            <true/>
+          </dict>
+          </plist>
+          EOF
+
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/build.xcarchive" \
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \
+            -exportPath "$RUNNER_TEMP/ios-build"
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-release-ipa
+          path: ${{ runner.temp }}/ios-build/*.ipa
+
+      - name: Upload to App Store Connect
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.upload_to_app_store) }}
+        env:
+          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+        run: |
+          IPA_FILE=$(find "$RUNNER_TEMP/ios-build" -name "*.ipa" | head -1)
+          if [ -z "$IPA_FILE" ]; then
+            echo "No IPA file found"
+            exit 1
+          fi
+
+          mkdir -p "$RUNNER_TEMP/appstore_api_key"
+          cat > "$RUNNER_TEMP/appstore_api_key/AuthKey_${APPSTORE_API_KEY_ID}.p8" << EOF
+          $APPSTORE_API_PRIVATE_KEY
+          EOF
+
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$IPA_FILE" \
+            --apiKey "$APPSTORE_API_KEY_ID" \
+            --apiKeyIssuer "$APPSTORE_API_ISSUER_ID"
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          if [ -f "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH"
+          fi

--- a/.github/workflows/trunk-validation.yml
+++ b/.github/workflows/trunk-validation.yml
@@ -124,3 +124,29 @@ jobs:
             android/**/build/tmp/kotlin-classes/**
             android/**/build/*.log
           if-no-files-found: ignore
+
+  ios-prebuild:
+    runs-on: macos-latest
+    needs: static
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate iOS native project
+        run: npx expo prebuild --platform ios --non-interactive
+
+      - name: Install CocoaPods dependencies
+        run: pod install
+        working-directory: ios

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ app-example
 # generated native folders
 /ios
 /android
+ios-build/
+DerivedData/
+*.xcarchive
 
 # Expo / EAS local config
 app.json

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 [![Get it on Google Play](https://img.shields.io/badge/Get_it_on-Google_Play-4285F4?style=for-the-badge&logo=googleplay&logoColor=white)](https://play.google.com/apps/testing/app.getopencode)
 [![Download APK](https://img.shields.io/badge/Download-APK-18A748?style=for-the-badge&logo=android&logoColor=white)](https://github.com/alvarolorentedev/opencode-mobile/releases/latest/download/opencode-mobile.apk)
+[![TestFlight](https://img.shields.io/badge/Join_Beta-TestFlight-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/)
 
 
 **Your OpenCode server, in your pocket.**
 
-OpenCode Mobile brings the full power of your self-hosted OpenCode AI assistant to your Android device. Chat with your models, manage conversations, and stay productive anywhere.
+OpenCode Mobile brings the full power of your self-hosted OpenCode AI assistant to your Android and iOS devices. Chat with your models, manage conversations, and stay productive anywhere.
 
 ## Why OpenCode Mobile?
 
@@ -22,6 +23,7 @@ OpenCode Mobile brings the full power of your self-hosted OpenCode AI assistant 
 
 1. **Download the app**:
    - [Google Play (Beta)](https://play.google.com/apps/testing/app.getopencode)
+   - [TestFlight (Beta)](https://testflight.apple.com/)
    - [Direct APK Download](https://github.com/alvarolorentedev/opencode-mobile/releases/latest/download/opencode-mobile.apk)
 
 2. **Connect to your server**: Open the app and enter your OpenCode server URL (default: `http://ip:4096`)
@@ -84,6 +86,8 @@ npm run typecheck      # Type checking
 npm run test:e2e:web   # End-to-end tests
 npm run android        # Build Android app
 npm run ios            # Build iOS app
+npm run prebuild:ios   # Generate iOS native project
+npm run build:ios:local # Build iOS release archive locally
 ```
 
 ### Android Builds
@@ -102,6 +106,58 @@ npm run build:development:android
 - Push to `main` to trigger Android release build and artifact upload
 - Push a version tag (e.g., `v1.2.3`) to trigger production Play Store upload
 - Use `workflow_dispatch` for manual internal-track uploads
+
+### iOS Builds
+
+Build a local iOS release:
+```bash
+npm run build:ios:local
+```
+
+**Prerequisites**:
+- Apple Developer Program membership ($99/year)
+- App Store Connect app created with bundle ID `app.getopencode`
+- Apple Distribution certificate (`.p12`) and provisioning profile
+- App Store Connect API key for TestFlight uploads
+
+**Required GitHub Secrets**:
+
+| Secret | Description |
+|--------|-------------|
+| `APPLE_CERTIFICATE_BASE64` | Base64-encoded Apple Distribution certificate (`.p12`) |
+| `APPLE_CERTIFICATE_PASSWORD` | Password for the `.p12` certificate |
+| `APPLE_PROVISIONING_PROFILE_BASE64` | Base64-encoded provisioning profile (`.mobileprovision`) |
+| `APPLE_TEAM_ID` | Apple Developer Team ID (10-character alphanumeric) |
+| `APPSTORE_API_KEY_ID` | App Store Connect API key ID |
+| `APPSTORE_API_ISSUER_ID` | App Store Connect API issuer ID |
+| `APPSTORE_API_PRIVATE_KEY` | App Store Connect API private key (`.p8` content) |
+
+**Creating the Apple Distribution Certificate**:
+1. Go to [Apple Developer Certificates](https://developer.apple.com/account/resources/certificates/list)
+2. Create a new "iOS Distribution" certificate
+3. Export as `.p12` with a password
+4. Base64-encode: `base64 -i certificate.p12 | pbcopy`
+5. Set `APPLE_CERTIFICATE_BASE64` and `APPLE_CERTIFICATE_PASSWORD` secrets
+
+**Creating the Provisioning Profile**:
+1. Go to [Apple Developer Profiles](https://developer.apple.com/account/resources/profiles/list)
+2. Create a new "App Store" provisioning profile for `app.getopencode`
+3. Download the `.mobileprovision` file
+4. Base64-encode: `base64 -i profile.mobileprovision | pbcopy`
+5. Set `APPLE_PROVISIONING_PROFILE_BASE64` secret
+
+**Creating the App Store Connect API Key**:
+1. Go to [App Store Connect > Users and Access > Integrations](https://appstoreconnect.apple.com/access/integrations/api)
+2. Generate a new API key with "Developer" access
+3. Download the `.p8` key file
+4. Note the Key ID and Issuer ID
+5. Set `APPSTORE_API_KEY_ID`, `APPSTORE_API_ISSUER_ID`, and `APPSTORE_API_PRIVATE_KEY` secrets
+
+**Release Automation**:
+- Push to `main` to trigger iOS release build and artifact upload
+- Push a version tag (e.g., `v1.2.3`) to trigger production TestFlight upload
+- Use `workflow_dispatch` with `upload_to_app_store: true` for manual TestFlight uploads
+- The `.ipa` artifact can be found in the workflow run's artifacts section
 
 ### Testing
 

--- a/app.config.ts
+++ b/app.config.ts
@@ -46,6 +46,8 @@ const config: ExpoConfig = {
     favicon: './assets/images/favicon.png',
   },
   ios: {
+    bundleIdentifier: 'app.getopencode',
+    buildNumber: '10',
     infoPlist: {
       NSAppTransportSecurity: {
         NSAllowsArbitraryLoads: true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "test:ci:static": "npm run lint && npm run typecheck && npm run test:usage && npm run test:format && npm run test:provider-utils && npm run test:workspace-patch",
     "build:android": "node ./scripts/build-android-release.mjs",
     "build:development:android": "node ./scripts/build-android-development.mjs",
-    "ios": "expo run:ios"
+    "ios": "expo run:ios",
+    "prebuild:ios": "expo prebuild --platform ios --non-interactive",
+    "build:ios:local": "node ./scripts/build-ios-release.mjs"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",

--- a/scripts/build-ios-release.mjs
+++ b/scripts/build-ios-release.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+/**
+ * iOS release build script.
+ *
+ * Generates the native iOS project via Expo prebuild, then builds a signed
+ * archive and exports an .ipa for App Store distribution.
+ *
+ * Required env vars:
+ *   APPLE_CERTIFICATE_BASE64      – base64-encoded .p12 distribution certificate
+ *   APPLE_CERTIFICATE_PASSWORD    – password for the .p12
+ *   APPLE_PROVISIONING_PROFILE_BASE64 – base64-encoded .mobileprovision
+ *   IOS_TEAM_ID                   – Apple Developer Team ID
+ *
+ * Optional env vars:
+ *   IOS_BUILD_NUMBER              – override auto-derived build number
+ *   IOS_SCHEME                    – override auto-detected Xcode scheme
+ *   IOS_EXPORT_METHOD             – distribution method (default: app-store)
+ *   EXPO_APP_VARIANT              – app variant (default: production)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
+import os from 'node:os';
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function requireEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) fail(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { stdio: 'inherit', ...options });
+  if (result.status !== 0) fail(`Command failed: ${command} ${args.join(' ')}`);
+}
+
+const repoRoot = process.cwd();
+const iosDir = path.join(repoRoot, 'ios');
+
+if (fs.existsSync(iosDir)) {
+  fs.rmSync(iosDir, { recursive: true, force: true });
+}
+
+// 1. Generate native iOS project
+console.log('Running Expo prebuild for iOS...');
+run('npx', ['expo', 'prebuild', '--platform', 'ios', '--non-interactive'], {
+  cwd: repoRoot,
+  env: {
+    ...process.env,
+    EXPO_APP_VARIANT: process.env.EXPO_APP_VARIANT || 'production',
+  },
+});
+
+// 2. Detect workspace and scheme
+const workspaces = fs.readdirSync(iosDir).filter((f) => f.endsWith('.xcworkspace'));
+if (workspaces.length === 0) fail('No .xcworkspace found after prebuild.');
+const workspacePath = path.join(iosDir, workspaces[0]);
+
+let scheme = process.env.IOS_SCHEME;
+if (!scheme) {
+  const listOutput = execSync(
+    `xcodebuild -workspace "${workspacePath}" -list -json`,
+    { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] },
+  );
+  const parsed = JSON.parse(listOutput);
+  scheme = parsed.project?.schemes?.[0];
+  if (!scheme) fail('Could not detect Xcode scheme. Set IOS_SCHEME.');
+}
+console.log(`Using scheme: ${scheme}`);
+
+// 3. Derive build number
+const buildNumber = process.env.IOS_BUILD_NUMBER || String(Date.now());
+console.log(`Build number: ${buildNumber}`);
+
+// 4. Create archive
+const archivePath = path.join(os.tmpdir(), 'build.xcarchive');
+const exportMethod = process.env.IOS_EXPORT_METHOD || 'app-store';
+
+run('xcodebuild', [
+  '-workspace', workspacePath,
+  '-scheme', scheme,
+  '-configuration', 'Release',
+  '-archivePath', archivePath,
+  '-destination', 'generic/platform=iOS',
+  '-allowProvisioningUpdates',
+  `DEVELOPMENT_TEAM=${requireEnv('IOS_TEAM_ID')}`,
+  `CURRENT_PROJECT_VERSION=${buildNumber}`,
+  'COMPILER_INDEX_STORE_ENABLE=NO',
+], { cwd: path.join(iosDir, scheme) });
+
+if (!fs.existsSync(archivePath)) fail('Archive not found at expected path.');
+
+// 5. Export IPA
+const exportOptionsPlist = path.join(os.tmpdir(), 'ExportOptions.plist');
+const exportOptionsContent = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>${exportMethod}</string>
+  <key>teamID</key>
+  <string>${requireEnv('IOS_TEAM_ID')}</string>
+  <key>uploadBitcode</key>
+  <false/>
+  <key>compileBitcode</key>
+  <false/>
+  <key>uploadSymbols</key>
+  <true/>
+</dict>
+</plist>`;
+fs.writeFileSync(exportOptionsPlist, exportOptionsContent);
+
+const ipaDir = path.join(repoRoot, 'ios-build');
+run('xcodebuild', [
+  '-exportArchive',
+  '-archivePath', archivePath,
+  '-exportOptionsPlist', exportOptionsPlist,
+  '-exportPath', ipaDir,
+]);
+
+const ipaFiles = fs.readdirSync(ipaDir).filter((f) => f.endsWith('.ipa'));
+if (ipaFiles.length === 0) fail('No .ipa file produced.');
+
+console.log(`iOS build complete: ${path.join(ipaDir, ipaFiles[0])}`);


### PR DESCRIPTION
- Add ios-release.yml workflow (macOS runner, keychain signing, IPA export, TestFlight upload)
- Add scripts/build-ios-release.mjs for local signed builds
- Add iOS config to app.config.ts (bundleIdentifier, buildNumber)
- Add prebuild:ios and build:ios:local npm scripts
- Add lightweight ios-prebuild job to trunk-validation.yml
- Update .gitignore for iOS build artifacts
- Update README with iOS release documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for building and distributing the app on iOS.
  - Added TestFlight availability for iOS releases.
  - Added automated iOS release builds with optional App Store Connect uploads.
  - Added local iOS release build commands for development teams.

- **Documentation**
  - Updated setup and release guidance with iOS prerequisites, development commands, signing configuration, and distribution instructions.

- **Chores**
  - Added safeguards to exclude iOS build artifacts and temporary Xcode files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->